### PR TITLE
Bug #143579 [IOS] Email & Password should be display space 

### DIFF
--- a/src/wsm/wsm/viewcontrollers/Login/LoginViewController.swift
+++ b/src/wsm/wsm/viewcontrollers/Login/LoginViewController.swift
@@ -17,11 +17,6 @@ class LoginViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        //dummy
-        emailTextField.text = "le.thanh.quang@framgia.com.edev"
-        passwordTextField.text = "123456"
-
         emailTextField.setLeftImage(size: emailTextField.frame.height,
                                     image: "ic_personal_information",
                                     color: UIColor.white)


### PR DESCRIPTION
https://dev.framgia.com/redmine/issues/143579
[IOS] Email & Password should be display space before user inputs the data on Login screen